### PR TITLE
Fix registry URL

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: 12
-        registry-url: 'https://npm.pkg.github.com'
+        registry-url: https://registry.npmjs.org/
     - name: Install dependencies 
       run: npm i
     - name: Publish to NPM

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koa-icon",
   "version": "1.1.0",
-  "description": "🚀 Lighting fast favicon middleware for Koa",
+  "description": "Lighting fast favicon middleware for Koa",
   "main": "lib/index.js",
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
Fixed CD workflow by using the correct NPM registry URL. Also removed the 🚀 emoji from the package description.