### PR TITLE
Support nodejs version 14 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [10, 12]
+        node: [10, 12, 14]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
CI had been updated to run tests on nodejs version 14 LTS.