### PR TITLE
Remove dependabot pull request limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,3 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 30


### PR DESCRIPTION
Removes the 30 pull requests limit that dependabot can open